### PR TITLE
feat: update elder listeners when incoming messages available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "sn_client"
-version = "0.44.17"
+version = "0.44.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -36,6 +36,7 @@ type TransferValidationSender = Sender<Result<TransferValidated, Error>>;
 type QueryResponseSender = Sender<Result<QueryResponse, Error>>;
 
 struct ElderConnection {
+    #[allow(dead_code)]
     listener: NetworkListenerHandle,
     socket_addr: SocketAddr,
 }
@@ -111,7 +112,7 @@ impl ConnectionManager {
             let msg_bytes_clone = msg_bytes.clone();
             let (connection, incoming) = endpoint.connect_to(&elder.socket_addr).await?;
 
-            if let Some(incoming_messages) = incoming {
+            if incoming.is_some() {
                 let socket_addr = elder.socket_addr;
                 error!("no listener exists for elder: {:?}", socket_addr);
             }
@@ -233,7 +234,7 @@ impl ConnectionManager {
             let endpoint = endpoint.lock().await;
             let (connection, incoming) = endpoint.connect_to(&elder.socket_addr).await?;
 
-            if let Some(_) = incoming {
+            if incoming.is_some() {
                 warn!(
                     "No listener established for elder connection {:?}",
                     elder.socket_addr


### PR DESCRIPTION
Use `incomingMessage` listener when available on query/cmd